### PR TITLE
Ep3 - Render Client Components in Server Components

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -92,25 +92,19 @@ async function buildForClient() {
           </head>
           <body>
           <div class="desc">
-          <h1>Manually split component into client part & server part - Ep2 of <a href="https://github.com/JSerZANP/demystify-react-server-components">Demystify React Server Components</a></h1>
-          <div>To address the issues from <a href="https://github.com/JSerZANP/demystify-react-server-components/pull/1">Ep1</a>, we'll do following:<br>
+          <h1>Render Client Components in Server Components - Ep3 of <a href="https://github.com/JSerZANP/demystify-react-server-components">Demystify React Server Components</a></h1>
+          <div>We couldn't move PostList to server as we did in ep2 because it renders <Link/> and <Link/> needs DOM api which means it must be a Client Component.<br>
+          In this episode, we do following to address this issue
+
           <ol>
-          <li>manually split PostDetail into PostDetail.client & PostDetail.server</li>
-          <li>PostDetail.client just pass down the props and query response from /render</li>
-          <li>/render will render PostDetail.server into JSON and send it back</li>
-          <li>PostDetail.client renders the response</li>
+          <li>when rendering Server Component, we replace Client Components with "LazyContainer"  </li>
+          <li>"LazyContainer" will be replaced with working client component -LazyContainer on client</li>
+          <li>LazyContainer lazy loads the actual component (Link in our case) and renders</li>
           </ol>
 
-          By above steps, we have a rough Server Component working for us(We do the same for PostDetail as well), we managed to 
-          <ol>
-          <li>move markdown related dependencies to server</li>
-          <li>remove data API endpoints</li>
-          </ol>
+          With this we are able to move PostList to a Server Component, Hooray! Check the app below to see the lazily loaded js resources.
           
-          <p>Sounds good! But it doesn't support nested components though, we cannot do the same to PostList, we'll try to fix this in next episode.</p>
-
-          <p>Here is the improve app, open Network tab from Chrome Dev Console to see the requests of /render.</p>
-
+          <p>But it is even more tedious now, how can we make it less painful?</p>
           </div>
           <div id="root"></div>
             ${scripts}

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -36,7 +36,11 @@ function transpile() {
  */
 async function buildForClient() {
   const bundle = await rollup({
-    input: [dir_built + "/Root.js"],
+    input: [
+      dir_built + "/Root.js",
+      dir_built + "/framework/LazyContainer.js",
+      dir_built + "/framework/Link.js",
+    ],
     plugins: [
       replace({ "process.env.NODE_ENV": JSON.stringify("production") }),
       commonjs(),

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -1,5 +1,5 @@
 import React, { Suspense } from "react";
-import PostList from "./PostList";
+import PostList from "./PostList.client";
 
 export default function List() {
   return (

--- a/src/components/PostList.client.jsx
+++ b/src/components/PostList.client.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import deserialize from "../framework/deserialize";
 import Link from "../framework/Link";
 
 const Posts = {
@@ -23,15 +24,7 @@ const Posts = {
       })
         .then((res) => res.text())
         .then((str) => {
-          this.data = JSON.parse(str, (key, value) => {
-            if (key === "$$typeof") {
-              if (value === "Symbol(react.element)") {
-                return Symbol.for("react.element");
-              }
-              throw new Error("unexpected $$typeof", value);
-            }
-            return value;
-          });
+          this.data = deserialize(str);
         });
     }
 
@@ -40,14 +33,5 @@ const Posts = {
 };
 
 export default function PostList() {
-  const list = Posts.fetch();
-  return (
-    <ol>
-      {list.map((post) => (
-        <li>
-          <Link href={`/post/${post.permalink}`}>{post.title}</Link>
-        </li>
-      ))}
-    </ol>
-  );
+  return Posts.fetch();
 }

--- a/src/components/PostList.client.jsx
+++ b/src/components/PostList.client.jsx
@@ -1,0 +1,53 @@
+import React from "react";
+import Link from "../framework/Link";
+
+const Posts = {
+  data: null,
+  promise: null,
+  fetch() {
+    if (this.data != null) {
+      return this.data;
+    }
+
+    if (this.promise == null) {
+      const payload = {
+        component: "PostList",
+        props: {},
+      };
+      this.promise = fetch("/render", {
+        body: JSON.stringify(payload),
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+        .then((res) => res.text())
+        .then((str) => {
+          this.data = JSON.parse(str, (key, value) => {
+            if (key === "$$typeof") {
+              if (value === "Symbol(react.element)") {
+                return Symbol.for("react.element");
+              }
+              throw new Error("unexpected $$typeof", value);
+            }
+            return value;
+          });
+        });
+    }
+
+    throw this.promise;
+  },
+};
+
+export default function PostList() {
+  const list = Posts.fetch();
+  return (
+    <ol>
+      {list.map((post) => (
+        <li>
+          <Link href={`/post/${post.permalink}`}>{post.title}</Link>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/src/components/PostList.server.jsx
+++ b/src/components/PostList.server.jsx
@@ -1,6 +1,3 @@
-import React from "react";
-import Link from "../framework/Link";
-
 const Posts = {
   data: null,
   promise: null,
@@ -20,14 +17,5 @@ const Posts = {
 };
 
 export default function PostList() {
-  const list = Posts.fetch();
-  return (
-    <ol>
-      {list.map((post) => (
-        <li>
-          <Link href={`/post/${post.permalink}`}>{post.title}</Link>
-        </li>
-      ))}
-    </ol>
-  );
+  return Posts.fetch();
 }

--- a/src/components/PostList.server.jsx
+++ b/src/components/PostList.server.jsx
@@ -7,7 +7,7 @@ export default async function PostList() {
   return (
     <ol>
       {list.map((post) => (
-        <li>
+        <li key={post.permalink}>
           <Link href={`/post/${post.permalink}`}>{post.title}</Link>
         </li>
       ))}

--- a/src/components/PostList.server.jsx
+++ b/src/components/PostList.server.jsx
@@ -1,21 +1,16 @@
-const Posts = {
-  data: null,
-  promise: null,
-  fetch() {
-    if (this.data != null) {
-      return this.data;
-    }
+import React from "react";
+import getPosts from "../server/posts";
+import Link from "../framework/Link";
 
-    if (this.promise == null) {
-      this.promise = fetch("/api/posts")
-        .then((res) => res.json())
-        .then((list) => (this.data = list));
-    }
-
-    throw this.promise;
-  },
-};
-
-export default function PostList() {
-  return Posts.fetch();
+export default async function PostList() {
+  const list = await getPosts();
+  return (
+    <ol>
+      {list.map((post) => (
+        <li>
+          <Link href={`/post/${post.permalink}`}>{post.title}</Link>
+        </li>
+      ))}
+    </ol>
+  );
 }

--- a/src/framework/LazyContainer.js
+++ b/src/framework/LazyContainer.js
@@ -1,0 +1,39 @@
+import React from "react";
+
+const fetcherMap = new Map();
+
+function createFetcher(componentName) {
+  return {
+    data: null,
+    promise: null,
+    fetch() {
+      if (this.data != null) {
+        return this.data;
+      }
+      if (this.promise == null) {
+        this.promise = import("/static/" + componentName + ".js").then(
+          (module) => {
+            this.data = module.default;
+          }
+        );
+      }
+
+      throw this.promise;
+    },
+  };
+}
+
+const fetch = (componentName) => {
+  if (!fetcherMap.has(componentName)) {
+    fetcherMap.set(componentName, createFetcher(componentName));
+  }
+  return fetcherMap.get(componentName).fetch();
+};
+
+/**
+ * dynamically fetches a component and renders
+ */
+export default function LazyContainer({ componentName, ...rest }) {
+  const Component = fetch(componentName);
+  return <Component {...rest} />;
+}

--- a/src/framework/deserialize.js
+++ b/src/framework/deserialize.js
@@ -1,0 +1,46 @@
+import LazyContainer from "./LazyContainer";
+
+/**
+ * parse server rendering response string so it could be used by React runtime
+ * 1. revive symbols
+ * 2. inject LazyContainer for client components
+ */
+export default function deserialize(str) {
+  const data = JSON.parse(str, (key, value) => {
+    if (key === "$$typeof") {
+      if (value === "Symbol(react.element)") {
+        return Symbol.for("react.element");
+      }
+      throw new Error("unexpected $$typeof", value);
+    }
+    return value;
+  });
+  const result = replaceClientComponent(data);
+  return result;
+}
+
+function replaceClientComponent(data) {
+  if (data == null || typeof data !== "object") {
+    return data;
+  }
+
+  if (Array.isArray(data)) {
+    return data.map(replaceClientComponent);
+  }
+
+  // if it is client component
+  // switch it to LazyContainer
+  if (data.type === "$LazyContainer") {
+    return {
+      ...data,
+      props: replaceClientComponent(data.props),
+      type: LazyContainer,
+    };
+  }
+
+  return Object.keys(data).reduce((result, key) => {
+    const value = replaceClientComponent(data[key]);
+    result[key] = value;
+    return result;
+  }, {});
+}

--- a/src/framework/serialize.js
+++ b/src/framework/serialize.js
@@ -25,6 +25,8 @@ function replaceClientComponent(data) {
 
   // if it is client component
   // switch it to LazyContainer
+  // we assume all function components are client components, which clearly is not true
+  // TODO: fix this
   if (
     data.$$typeof === Symbol.for("react.element") &&
     typeof data.type === "function"

--- a/src/framework/serialize.js
+++ b/src/framework/serialize.js
@@ -1,0 +1,48 @@
+/**
+ * serialize server rendering result
+ * 1. replace symbols
+ * 2. replace client component with placeholder
+ */
+export default function serialize(json) {
+  const replaced = replaceClientComponent(json);
+
+  return JSON.stringify(replaced, (k, v) => {
+    if (k === "$$typeof" && typeof v === "symbol") {
+      return v.toString();
+    }
+    return v;
+  });
+}
+
+function replaceClientComponent(data) {
+  if (data == null || typeof data !== "object") {
+    return data;
+  }
+
+  if (Array.isArray(data)) {
+    return data.map(replaceClientComponent);
+  }
+
+  // if it is client component
+  // switch it to LazyContainer
+  if (
+    data.$$typeof === Symbol.for("react.element") &&
+    typeof data.type === "function"
+  ) {
+    return {
+      ...data,
+      props: {
+        ...replaceClientComponent(data.props),
+        // TODO: key conflict
+        componentName: data.type.name,
+      },
+      type: "$LazyContainer",
+    };
+  }
+
+  return Object.keys(data).reduce((result, key) => {
+    const value = replaceClientComponent(data[key]);
+    result[key] = value;
+    return result;
+  }, {});
+}

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,6 +1,7 @@
 import bodyParser from "body-parser";
 import express from "express";
 import path from "path";
+import serialize from "../framework/serialize";
 import getPosts from "./posts";
 
 const app = express();
@@ -26,13 +27,7 @@ app.post("/render", async (req, res) => {
 
   // assume all server components are async for now
   const json = await Component(props);
-  const str = JSON.stringify(json, (k, v) => {
-    if (k === "$$typeof" && typeof v === "symbol") {
-      return v.toString();
-    }
-    return v;
-  });
-
+  const str = serialize(json);
   res.send(str);
 });
 

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -2,7 +2,6 @@ import bodyParser from "body-parser";
 import express from "express";
 import path from "path";
 import serialize from "../framework/serialize";
-import getPosts from "./posts";
 
 const app = express();
 const port = 3000;
@@ -11,12 +10,6 @@ app.use(bodyParser.json());
 
 // serve static files under public/
 app.use("/static", express.static(path.join(__dirname, "../../public")));
-
-// API exposed for client-side use
-app.get("/api/posts", async (req, res) => {
-  const list = await getPosts();
-  res.json(list);
-});
 
 app.post("/render", async (req, res) => {
   const { component, props } = req.body;


### PR DESCRIPTION
We couldn't move PostList to server as we did in [ep2](https://github.com/JSerZANP/demystify-react-server-components/pull/2) because it renders `<Link/>`  and `<Link/>` needs DOM api which means it must be a Client Component

In this episode, we do following to address this issue

1. when rendering Server Component, we replace Client Components with `"LazyContainer"`
2. `"LazyContainer"` will be replaced with working client component -`LazyContainer` on client
3. LazyContainer lazy loads the actual component (`Link` in our case) and renders

With this we are able to move PostList to a Server Component, Hooray!

But it is even more tedious now, how can we make it less painful?