### PR TITLE
Ep5 - Support nested Server Components & Suspense

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -119,20 +119,22 @@ async function buildForClient() {
           </head>
           <body>
           <div class="desc">
-          <h1>Automatically build Server Components - Ep4 of <a href="https://github.com/JSerZANP/demystify-react-server-components">Demystify React Server Components</a></h1>
-          <div>In <a href="https://github.com/JSerZANP/demystify-react-server-components/pull/3">ep3</a> we see how tedious it is to manually manage the client part of server component.<br>
-          After doing two components, we can see that the client part of server components are basically the same, it is just a loader component that communicates with /render.<br>
-So we modify the build scripts to do this for us so that
-
-
-
-
+          <h1>Support nested Server Components & Suspense - Ep5 of <a href="https://github.com/JSerZANP/demystify-react-server-components">Demystify React Server Components</a></h1>
+          <div>So far we couldn't move page-level components \`List\` & \`Detail\` to Server Components because <br>
           <ol>
-          <li>default components are Server Components, unless "use client" is declared  </li>
-          <li>no more naming of .server.js or .client.js. Now after building, client code use /public, server uses /built, components have the same name across the folders.</li>
+          <li> they have nested Server Components, but we only render one level in our code</li>
+          <li> they have Suspense</li>
           </ol>
-
-          Here is the new app, we can see it works totally the same as before but the code is much cleaner with out importing '.client' or '.server'
+          
+          Let's tweak the code a little bit so that <br>
+          <ol>
+          <li> nested Server Components can be supported (not directly rendered though, we only send down their client part and they will be rendered by another request. This creates a waterfall)</li>
+          <li>Suspense is supported: this could be easily done because Suspense is built-in component</li>
+          </ol>
+          
+          With this new demo, we can see the Suspenses be rendered. <br>
+          
+          We don't want the /render to be called multiple times though, with what we've learnt from [How progressive hydration works](https://jser.dev/react/2023/03/30/progressive-hydration.html), we can try stream down the responses in one request, let's give it a try in following episode<br>
           
           </div>
           <div id="root"></div>

--- a/src/components/Detail.jsx
+++ b/src/components/Detail.jsx
@@ -1,4 +1,3 @@
-"use client";
 import React, { Suspense } from "react";
 import Link from "../framework/Link";
 

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -1,4 +1,3 @@
-"use client";
 import React, { Suspense } from "react";
 import PostList from "./PostList";
 

--- a/src/framework/Router.jsx
+++ b/src/framework/Router.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useEffect, useState } from "react";
 import Detail from "../components/Detail";
 import List from "../components/List";
+import { startTransition } from "react";
 
 function getRoute() {
   const path = location.pathname;
@@ -20,7 +21,7 @@ export default function Router() {
 
   useEffect(() => {
     const onChange = () => {
-      setPage(getRoute());
+      startTransition(() => setPage(getRoute()));
     };
     window.addEventListener("popstate", onChange);
     return () => {

--- a/src/framework/deserialize.js
+++ b/src/framework/deserialize.js
@@ -13,6 +13,11 @@ export default function deserialize(str) {
       }
       throw new Error("unexpected $$typeof", value);
     }
+
+    if (key === "type" && value === "Symbol(react.suspense)") {
+      return Symbol.for("react.suspense");
+    }
+
     return value;
   });
   const result = replaceClientComponent(data);

--- a/src/framework/renderServerComponent.js
+++ b/src/framework/renderServerComponent.js
@@ -1,0 +1,48 @@
+/**
+ * recursively render server component
+ * if meet function component, replace it with lazyContainer
+ * remember that Server Components have a client part, meaning it could be lazy loaded too.
+ */
+export default function render(jsx) {
+  if (jsx == null) {
+    return null;
+  }
+
+  if (
+    typeof jsx === "string" ||
+    typeof jsx === "number" ||
+    typeof jsx === "symbol"
+  ) {
+    return jsx;
+  }
+
+  if (Array.isArray(jsx)) {
+    return jsx.map((item) => render(item));
+  }
+
+  // we only process React elemnts
+  if (jsx["$$typeof"] === Symbol.for("react.element")) {
+    // if intrinsic html tag
+    if (typeof jsx.type === "string") {
+      return { ...jsx, props: render(jsx.props) };
+    }
+
+    // if function components, just replace it with LazyContainer
+    // we don't differentiate client or server components here
+    if (typeof jsx.type === "function") {
+      return {
+        ...jsx,
+        props: {
+          ...render(jsx.props),
+          componentName: jsx.type.name,
+        },
+        type: "$LazyContainer",
+      };
+    }
+  }
+
+  return Object.keys(jsx).reduce((result, key) => {
+    result[key] = render(jsx[key]);
+    return result;
+  }, {});
+}

--- a/src/framework/serialize.js
+++ b/src/framework/serialize.js
@@ -4,47 +4,17 @@
  * 2. replace client component with placeholder
  */
 export default function serialize(json) {
-  const replaced = replaceClientComponent(json);
-
-  return JSON.stringify(replaced, (k, v) => {
+  return JSON.stringify(json, (k, v) => {
+    // Symbol.for'('react.element')
     if (k === "$$typeof" && typeof v === "symbol") {
       return v.toString();
     }
+
+    // Symbol.for('react.suspense')
+    if (k === "type" && typeof v === "symbol") {
+      return v.toString();
+    }
+
     return v;
   });
-}
-
-function replaceClientComponent(data) {
-  if (data == null || typeof data !== "object") {
-    return data;
-  }
-
-  if (Array.isArray(data)) {
-    return data.map(replaceClientComponent);
-  }
-
-  // if it is client component
-  // switch it to LazyContainer
-  // we assume all function components are client components, which clearly is not true
-  // TODO: fix this
-  if (
-    data.$$typeof === Symbol.for("react.element") &&
-    typeof data.type === "function"
-  ) {
-    return {
-      ...data,
-      props: {
-        ...replaceClientComponent(data.props),
-        // TODO: key conflict
-        componentName: data.type.name,
-      },
-      type: "$LazyContainer",
-    };
-  }
-
-  return Object.keys(data).reduce((result, key) => {
-    const value = replaceClientComponent(data[key]);
-    result[key] = value;
-    return result;
-  }, {});
 }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,6 +1,7 @@
 import bodyParser from "body-parser";
 import express from "express";
 import path from "path";
+import renderServerComponent from "../framework/renderServerComponent";
 import serialize from "../framework/serialize";
 
 const app = express();
@@ -20,7 +21,7 @@ app.post("/render", async (req, res) => {
 
   // assume all server components are async for now
   const json = await Component(props);
-  const str = serialize(json);
+  const str = serialize(renderServerComponent(json));
   res.send(str);
 });
 


### PR DESCRIPTION
So far we couldn't move page-level components `List ` & `Detail` to Server Components because 

1. they have nested Server Components, but we only render one level in our code
2. they have Suspense

Let's tweak the code a little bit so that 
1. nested Server Components can be supported (not directly rendered though, we only send down their client part and they will be rendered by another request. This creates a waterfall)
2. Suspense is supported: this could be easily done because Suspense is built-in component

With this new demo, we can see the Suspenses be rendered. 

We don't want the /render to be called multiple times though, with what we've learnt from [How progressive hydration works](https://jser.dev/react/2023/03/30/progressive-hydration.html), we can try stream down the responses in one request.
