### PR TITLE
ep6 - render Server Components and stream down response

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -164,6 +164,25 @@ function removeBuiltFiles() {
   deleteFilesRecursive(dir_public);
 }
 
+async function generateComponentMap() {
+  const { serverComponents, clientComponents } = await readAllComponents();
+
+  // TODO: the client components from framework should be built
+  writeFileSync(
+    dir_built + "/utils/componentMap.js",
+    `
+module.exports =  {
+  serverComponents: [${serverComponents
+    .map((file) => `"${file.fileName.split(".")[0]}"`)
+    .join(",")}],
+  clientComponents: [${clientComponents
+    .map((file) => `"${file.fileName.split(".")[0]}"`)
+    .join(",")},  "Link", "LazyContainer"],
+}
+    `
+  );
+}
+
 async function start() {
   // build with a fresh start
   removeBuiltFiles();
@@ -177,6 +196,9 @@ async function start() {
 
   // for server build, just transpile it again as a quick fix
   transpile();
+
+  // genreate a component map so that on server we can easily tell if a component is client component
+  await generateComponentMap();
 }
 
 start();

--- a/src/framework/Placeholder.js
+++ b/src/framework/Placeholder.js
@@ -1,0 +1,3 @@
+export default function Placeholder({ id }) {
+  throw new Promise(() => {});
+}

--- a/src/framework/deserialize.js
+++ b/src/framework/deserialize.js
@@ -1,4 +1,5 @@
 import LazyContainer from "./LazyContainer";
+import Placeholder from "./Placeholder";
 
 /**
  * parse server rendering response string so it could be used by React runtime
@@ -40,6 +41,14 @@ function replaceClientComponent(data) {
       ...data,
       props: replaceClientComponent(data.props),
       type: LazyContainer,
+    };
+  }
+
+  if (data.type === "$Placeholder") {
+    return {
+      ...data,
+      props: replaceClientComponent(data.props),
+      type: Placeholder,
     };
   }
 

--- a/src/framework/renderServerComponent.js
+++ b/src/framework/renderServerComponent.js
@@ -1,9 +1,34 @@
+import componentMap from "../../built/utils/componentMap";
+import serialize from "./serialize";
 /**
- * recursively render server component
- * if meet function component, replace it with lazyContainer
- * remember that Server Components have a client part, meaning it could be lazy loaded too.
+ *
+ * Render the JSX tree into a stream
+ *
+ * we actually want to use the jsx directly but we need more work to do
+ *
+ * 1. handling unserializable data;
+ *    - symbols -> this could be replaced & revived easily by its string
+ * 2. client component
+ *    - replace the client component with LazyContainer
+ * 3. server component
+ *    - if sync, just render it
+ *    - if async
+ *       - generate a unique id
+ *       - replace it with Placeholder component with the id
+ *          - streamed chunks could use the id to let client-side determine where to replace
+ *       - attach a then callback that renders later and stream the response
+ *          - the response might container furthur server components, just repeat the process
+ *
+ * On client-side
+ *
+ * 1. ClientBase as the communiation root to /render
+ *    - continuously parse the streamed response and build the final tree progressively
+ *    - put chunks at right location based on the id
+ * 2. Placeholder
+ *    - just throws a Promise which triggers the Suspense fallback
+ *    - once children response  comes in, Placeholder itself will be replaced.
  */
-export default function render(jsx) {
+function render(jsx, context) {
   if (jsx == null) {
     return null;
   }
@@ -17,32 +42,86 @@ export default function render(jsx) {
   }
 
   if (Array.isArray(jsx)) {
-    return jsx.map((item) => render(item));
+    return jsx.map((item) => render(item, context));
   }
 
-  // we only process React elemnts
+  // react elements are what we want to handle
   if (jsx["$$typeof"] === Symbol.for("react.element")) {
     // if intrinsic html tag
     if (typeof jsx.type === "string") {
-      return { ...jsx, props: render(jsx.props) };
+      return { ...jsx, props: render(jsx.props, context) };
     }
 
-    // if function components, just replace it with LazyContainer
-    // we don't differentiate client or server components here
+    // if function components
     if (typeof jsx.type === "function") {
-      return {
-        ...jsx,
-        props: {
-          ...render(jsx.props),
-          componentName: jsx.type.name,
-        },
-        type: "$LazyContainer",
-      };
+      // if client component
+      if (componentMap.clientComponents.includes(jsx.type.name)) {
+        return {
+          ...jsx,
+          props: {
+            ...render(jsx.props, context),
+            componentName: jsx.type.name,
+          },
+          type: "$LazyContainer",
+        };
+      } else {
+        // server compponent
+
+        // generate an id
+        const id = "C:" + context.id++;
+        const rendered = jsx.type(jsx.props);
+        if ("then" in rendered) {
+          // if an async function, then
+          // schedule a task to stream down the response
+          context.tasks.add(rendered);
+          rendered.then((json) => {
+            context.tasks.delete(rendered);
+            context.pipe({
+              target: id,
+              data: render(json, context),
+            });
+          });
+
+          // and return a placeholder
+          return {
+            $$typeof: Symbol.for("react.element"),
+            type: "$Placeholder",
+            props: {
+              id,
+            },
+            ref: null,
+          };
+        } else {
+          // if a sync function, just render it
+          return render(rendered, context);
+        }
+      }
     }
   }
 
   return Object.keys(jsx).reduce((result, key) => {
-    result[key] = render(jsx[key]);
+    result[key] = render(jsx[key], context);
     return result;
   }, {});
+}
+
+export default function renderServerComponentToStream(jsx, res) {
+  const context = {
+    id: 0,
+    tasks: new Set(),
+  };
+
+  const pipe = (json) => {
+    res.write(serialize(json));
+    if (context.tasks.size === 0) {
+      res.end();
+    }
+  };
+
+  context.pipe = pipe;
+
+  pipe({
+    target: "base",
+    data: render(jsx, context),
+  });
 }

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,8 +1,7 @@
 import bodyParser from "body-parser";
 import express from "express";
 import path from "path";
-import renderServerComponent from "../framework/renderServerComponent";
-import serialize from "../framework/serialize";
+import renderServerComponentToStream from "../framework/renderServerComponent";
 
 const app = express();
 const port = 3000;
@@ -19,10 +18,8 @@ app.post("/render", async (req, res) => {
     "../components/" + component + ".js"
   )).default;
 
-  // assume all server components are async for now
   const json = await Component(props);
-  const str = serialize(renderServerComponent(json));
-  res.send(str);
+  renderServerComponentToStream(json, res);
 });
 
 // serve built index.html


### PR DESCRIPTION
in [Ep5](https://github.com/JSerZANP/demystify-react-server-components/pull/5), we briefly mentioned the waterfall issue - we fetch `/render` multiple times for nested server components.

In this episode we improved this by streaming - progressively send down the already rendered chunks of server components.

The code is not complex actually, with previous episodes it is pretty natural to come this far. Open the Chrome Dev console to see that there is only 1 `/render` call for each page navigation.

This is the last episode of this mini series! Hope it somewhat helps.

Again this is of course not official implementation, I'm learning on the way as well.